### PR TITLE
Fix comment closure for dot grid styles

### DIFF
--- a/Child Theme Files/style.css
+++ b/Child Theme Files/style.css
@@ -236,7 +236,7 @@
 	background-color: var(--brandon-dot-color);
 	border-radius: 50%;
 	transform-origin: center center;
-	/* transition: transform 0.3s var(--brandon-transition-ease), opacity 0.3s var(--brandon-transition-ease);
+       /* transition: transform 0.3s var(--brandon-transition-ease), opacity 0.3s var(--brandon-transition-ease); */
 }
 
 /*

--- a/style.css
+++ b/style.css
@@ -236,7 +236,7 @@
 	background-color: var(--brandon-dot-color);
 	border-radius: 50%;
 	transform-origin: center center;
-	/* transition: transform 0.3s var(--brandon-transition-ease), opacity 0.3s var(--brandon-transition-ease);
+       /* transition: transform 0.3s var(--brandon-transition-ease), opacity 0.3s var(--brandon-transition-ease); */
 }
 
 /*


### PR DESCRIPTION
## Summary
- close comment for `.brandon-dots-grid .brandon-dot` transition line in both theme stylesheets

## Testing
- `grep -n '#row-navbar-top' style.css`


------
https://chatgpt.com/codex/tasks/task_e_684ffc0bc7e48331aa40f02d4942f968